### PR TITLE
[SDK-5590] Change http to https to get the fallback stream to always work

### DIFF
--- a/GoogleDAIDemo/app/src/main/java/com/jwplayer/googledai/MainActivity.java
+++ b/GoogleDAIDemo/app/src/main/java/com/jwplayer/googledai/MainActivity.java
@@ -36,7 +36,7 @@ public class MainActivity extends AppCompatActivity
         ImaDaiSettings imaDaiSettings = new ImaDaiSettings(videoId, cmsId, streamType, null);
         //fallbackUrl: Contain URL in case ads stream fails. This url will be use automatically
         //in case the DAI stream encounters an error
-        String fallbackUrl = "http://playertest.longtailvideo.com/adaptive/bipbop/gear4/prog_index.m3u8";
+        String fallbackUrl = "https://playertest.longtailvideo.com/adaptive/bipbop/gear4/prog_index.m3u8";
         PlaylistItem playlistItem = new PlaylistItem.Builder()
                 .file(fallbackUrl)
                 .imaDaiSettings(imaDaiSettings)


### PR DESCRIPTION
Changes the demo's fallback url to use https instead instead of http so the fallback stream works instead of running into an endless spinner