### PR TITLE
[SDK-8795] Fix Chromecast Fragment crashing by updating to SDK 4.2.0

### DIFF
--- a/ChromecastFragmentDemo/app/build.gradle
+++ b/ChromecastFragmentDemo/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
 
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         versionCode 1
         versionName "1.0"
@@ -27,11 +27,11 @@ android {
 }
 
 dependencies {
-    implementation'androidx.appcompat:appcompat:1.2.0'
-    implementation'com.google.android.material:material:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation'androidx.appcompat:appcompat:1.4.0'
+    implementation'com.google.android.material:material:1.4.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
 
-    def sdkVersion = '4.0.0'
+    def sdkVersion = '4.2.0'
 	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
 	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 	implementation "com.jwplayer:jwplayer-chromecast:${sdkVersion}"

--- a/ChromecastFragmentDemo/app/src/main/java/com/jwplayer/chromecastfragmentdemo/CastOptionsProvider.java
+++ b/ChromecastFragmentDemo/app/src/main/java/com/jwplayer/chromecastfragmentdemo/CastOptionsProvider.java
@@ -1,0 +1,50 @@
+package com.jwplayer.chromecastfragmentdemo;
+
+
+import android.content.Context;
+
+import com.google.android.gms.cast.CastMediaControlIntent;
+import com.google.android.gms.cast.framework.CastOptions;
+import com.google.android.gms.cast.framework.OptionsProvider;
+import com.google.android.gms.cast.framework.SessionProvider;
+import com.google.android.gms.cast.framework.media.CastMediaOptions;
+import com.google.android.gms.cast.framework.media.MediaIntentReceiver;
+import com.google.android.gms.cast.framework.media.NotificationOptions;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+public class CastOptionsProvider implements OptionsProvider {
+
+    /**
+     * The Application Id to use, currently the Default Media Receiver.
+     */
+    private static final String DEFAULT_APPLICATION_ID = CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID;
+
+    @Override
+    public CastOptions getCastOptions(Context context) {
+
+        final NotificationOptions notificationOptions = new NotificationOptions.Builder()
+                .setActions(Arrays.asList(
+                        MediaIntentReceiver.ACTION_SKIP_NEXT,
+                        MediaIntentReceiver.ACTION_TOGGLE_PLAYBACK,
+                        MediaIntentReceiver.ACTION_STOP_CASTING), new int[]{1, 2})
+                .setTargetActivityClassName(JWPlayerFragmentExample.class.getName())
+                .build();
+
+        final CastMediaOptions mediaOptions = new CastMediaOptions.Builder()
+                .setNotificationOptions(notificationOptions)
+                .build();
+
+        return new CastOptions.Builder()
+                .setReceiverApplicationId(DEFAULT_APPLICATION_ID)
+                .setCastMediaOptions(mediaOptions)
+                .build();
+    }
+
+    @Override
+    public List<SessionProvider> getAdditionalSessionProviders(Context appContext) {
+        return null;
+    }
+}


### PR DESCRIPTION
- Updates to SDK 4.2.0 which fixes the crash this demo was having in `onCreate()`
- Adds the `CastOptionsProvider` class which was missing