### PR TITLE
update license key and dependencies for aar files

### DIFF
--- a/ChromecastDemo/app/build.gradle
+++ b/ChromecastDemo/app/build.gradle
@@ -9,11 +9,11 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-	compileSdkVersion 31
+	compileSdkVersion 33
 
 	defaultConfig {
 		minSdkVersion 21
-		targetSdkVersion 31
+		targetSdkVersion 32
 		versionCode 1
 		versionName "1.0"
 		applicationId "com.jwplayer.chromecastdemo"
@@ -45,13 +45,43 @@ android {
 	}
 }
 
-dependencies {
-	implementation'androidx.appcompat:appcompat:1.4.1'
-	implementation'com.google.android.material:material:1.5.0'
-	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+ext.JWPlayerVersion = '4.10.2'
+ext.exoplayerVersion = '2.18.3'
 
-	def sdkVersion = '4.3.0'
-	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
-	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
-	implementation "com.jwplayer:jwplayer-chromecast:${sdkVersion}"
+dependencies {
+	implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+	implementation 'androidx.appcompat:appcompat:1.4.1'
+	implementation 'com.google.android.material:material:1.6.0'
+
+	implementation "com.jwplayer:jwplayer-core:$JWPlayerVersion"
+	implementation "com.jwplayer:jwplayer-common:$JWPlayerVersion"
+	implementation "com.jwplayer:jwplayer-chromecast:$JWPlayerVersion"
+	implementation "com.jwplayer:jwplayer-ima:$JWPlayerVersion"
+
+//	//  Only needed when building with AAR instead
+//	implementation fileTree(dir: 'libs', include: ['*.jar','*.aar'])
+//
+//	//	implementation fileTree(dir: 'libs', include: 'jwplayer-common-4.10.2.aar')
+//	//	implementation fileTree(dir: 'libs', include: 'jwplayer-core-4.10.2.aar')
+//	//	implementation fileTree(dir: 'libs', include: 'jwplayer-chromecast-4.10.2.aar')
+//	//	implementation fileTree(dir: 'libs', include: 'jwplayer-ima-4.10.2.aar')
+//
+//	implementation 'com.google.android.gms:play-services-cast-framework:21.2.0'
+//	implementation 'androidx.webkit:webkit:1.6.0'
+//	implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
+//	implementation "com.google.android.exoplayer:exoplayer-core:$exoplayerVersion"
+//	implementation "com.google.android.exoplayer:exoplayer-dash:$exoplayerVersion"
+//	implementation "com.google.android.exoplayer:exoplayer-hls:$exoplayerVersion"
+//	implementation "com.google.android.exoplayer:exoplayer-smoothstreaming:$exoplayerVersion"
+//	implementation "com.google.android.exoplayer:exoplayer-ui:$exoplayerVersion"
+//	implementation 'com.squareup.picasso:picasso:2.71828'
+//	implementation 'androidx.viewpager2:viewpager2:1.0.0'
+//	implementation 'com.android.volley:volley:1.2.1'
+//	implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+//	implementation 'androidx.recyclerview:recyclerview:1.2.1'
+//
+//	def lifecycle_version = "2.4.0"
+//	implementation "androidx.lifecycle:lifecycle-viewmodel:$lifecycle_version"
+//	implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+
 }

--- a/ChromecastDemo/app/src/main/java/com/jwplayer/chromecastdemo/JWPlayerViewExample.java
+++ b/ChromecastDemo/app/src/main/java/com/jwplayer/chromecastdemo/JWPlayerViewExample.java
@@ -49,7 +49,7 @@ public class JWPlayerViewExample extends AppCompatActivity
 		// INFO: Overwrite BuildConfig.JWPLAYER_LICENSE_KEY with your license here
 		// [OR] change in app-level build.gradle
 		// [OR] set JWPLAYER_LICENSE_KEY as environment variable
-		LicenseUtil.setLicenseKey(this, BuildConfig.JWPLAYER_LICENSE_KEY);
+		new LicenseUtil().setLicenseKey(this, BuildConfig.JWPLAYER_LICENSE_KEY);
 
 		mPlayerView = findViewById(R.id.jwplayer);
 

--- a/DemoNativeControls/app/build.gradle
+++ b/DemoNativeControls/app/build.gradle
@@ -10,11 +10,11 @@ if (isJenkinsBuild) {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.jwplayer.demo.nativecontrols"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -49,11 +49,13 @@ android {
 }
 
 dependencies {
+    def sdkVersion = '4.10.2'
+    implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
+    implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
+
     def lifecycle_version = "2.4.0"
     implementation "androidx.lifecycle:lifecycle-livedata:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
-
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
@@ -61,11 +63,33 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
-
-    def sdkVersion = '4.3.0'
-	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
-	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
-
     testImplementation 'junit:junit:4.13.2'
     implementation 'androidx.multidex:multidex:2.0.1'
+
+
+
+//    //  Only needed when building with AAR instead
+//    def exoplayerVersion = '2.18.3'
+//
+//    implementation 'androidx.appcompat:appcompat:1.4.1'
+//
+//    implementation fileTree(dir: 'libs', include: ['*.jar'])
+//	implementation 'com.google.android.gms:play-services-cast-framework:21.2.0'
+//	implementation 'androidx.webkit:webkit:1.6.0'
+//	implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
+//	implementation "com.google.android.exoplayer:exoplayer-core:$exoplayerVersion"
+//	implementation "com.google.android.exoplayer:exoplayer-dash:$exoplayerVersion"
+//	implementation "com.google.android.exoplayer:exoplayer-hls:$exoplayerVersion"
+//	implementation "com.google.android.exoplayer:exoplayer-smoothstreaming:$exoplayerVersion"
+//	implementation "com.google.android.exoplayer:exoplayer-ui:$exoplayerVersion"
+//	implementation 'com.squareup.picasso:picasso:2.71828'
+//	implementation 'androidx.viewpager2:viewpager2:1.0.0'
+//	implementation 'com.android.volley:volley:1.2.1'
+//	implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+//	implementation 'androidx.recyclerview:recyclerview:1.2.1'
+//
+//    implementation fileTree(dir: 'libs', include: 'jwplayer-common-4.10.2.aar')
+//	implementation fileTree(dir: 'libs', include: 'jwplayer-core-4.10.2.aar')
+//	implementation fileTree(dir: 'libs', include: 'jwplayer-chromecast-4.10.2.aar')
+//	implementation fileTree(dir: 'libs', include: 'jwplayer-ima-4.10.2.aar')
 }

--- a/DemoNativeControls/app/src/main/java/com/jwplayer/demo/nativecontrols/MainActivity.java
+++ b/DemoNativeControls/app/src/main/java/com/jwplayer/demo/nativecontrols/MainActivity.java
@@ -55,7 +55,7 @@ public class MainActivity extends AppCompatActivity
         // INFO: Overwrite BuildConfig.JWPLAYER_LICENSE_KEY with your license here
         // [OR] change in app-level build.gradle
         // [OR] set JWPLAYER_LICENSE_KEY as environment variable
-        LicenseUtil.setLicenseKey(this,BuildConfig.JWPLAYER_LICENSE_KEY );
+        new LicenseUtil().setLicenseKey(this, BuildConfig.JWPLAYER_LICENSE_KEY);
 
         mPlayerView = findViewById(R.id.jwplayer);
         mPlayer = mPlayerView.getPlayer();


### PR DESCRIPTION
Setting the license is not in static way, so we the change is to set the license with the instance instead.

Prepare the dependencies for using aar files, some dependencies were missing or not updated.