### PR TITLE
[SDK-10987][BPA] Offline content is still playing even when other content was not able to setup

### DIFF
--- a/OfflineDelegate/app/src/main/java/com/jwplayer/offlinedelegate/MainActivity.java
+++ b/OfflineDelegate/app/src/main/java/com/jwplayer/offlinedelegate/MainActivity.java
@@ -144,6 +144,10 @@ public class MainActivity extends AppCompatActivity
             ).show();
         });
         findViewById(R.id.setup).setOnClickListener(v -> {
+           if (mPlayer != null) {
+               mPlayer.stop();
+           }
+
             Download download = mOfflineDelegate.getDownload(mCurrentItem.getMediaId());
             boolean isDownloaded = download != null && download.state == Download.STATE_COMPLETED;
             if (mNetworkTracker.isOnline() || isDownloaded) {


### PR DESCRIPTION
* To prevent background audio after setup a no-offline content available
