### PR TITLE
Android 4.26.0 — SDK/media3/IMA bump, prod maven, JWCompose modernization

### DIFF
--- a/ChromecastDemo/app/build.gradle
+++ b/ChromecastDemo/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-	compileSdk 35
+	compileSdk 36
 
 	defaultConfig {
 		minSdkVersion 24
@@ -47,8 +47,8 @@ android {
     namespace 'com.jwplayer.chromecastdemo'
 }
 
-ext.JWPlayerVersion = '4.25.0'
-ext.media3exoplayer = '1.4.1'
+ext.JWPlayerVersion = '4.26.0'
+ext.media3exoplayer = '1.10.0'
 
 dependencies {
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/ChromecastDemo/build.gradle
+++ b/ChromecastDemo/build.gradle
@@ -14,7 +14,7 @@ allprojects {
 		mavenCentral()
 		gradlePluginPortal()
 		maven {
-			url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+			url 'https://mvn.jwplayer.com/content/repositories/releases/'
 		}
 	}
 }

--- a/CustomFragmentUi/app/build.gradle
+++ b/CustomFragmentUi/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdk 35
+	compileSdk 36
 	defaultConfig {
 		minSdkVersion 24
 		targetSdkVersion 35
@@ -24,8 +24,8 @@ android {
     namespace 'com.jwplayer.customfragment'
 }
 
-ext.JWPlayerVersion = '4.25.0'
-ext.media3version = '1.4.1'
+ext.JWPlayerVersion = '4.26.0'
+ext.media3version = '1.10.0'
 
 dependencies {
 	implementation 'androidx.appcompat:appcompat:1.3.1'

--- a/CustomFragmentUi/build.gradle
+++ b/CustomFragmentUi/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 		mavenCentral()
 		gradlePluginPortal()
 		maven {
-			url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+			url 'https://mvn.jwplayer.com/content/repositories/releases/'
 		}
 	}
 }

--- a/CustomUi/app/build.gradle
+++ b/CustomUi/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdk 35
+	compileSdk 36
 	defaultConfig {
 		minSdkVersion 24
 		targetSdkVersion 35
@@ -24,8 +24,8 @@ android {
     namespace 'com.jwplayer.customui'
 }
 
-ext.JWPlayerVersion = '4.25.0'
-ext.media3version = '1.4.1'
+ext.JWPlayerVersion = '4.26.0'
+ext.media3version = '1.10.0'
 
 dependencies {
 	implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/CustomUi/build.gradle
+++ b/CustomUi/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 		mavenCentral()
 		gradlePluginPortal()
 		maven {
-			url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+			url 'https://mvn.jwplayer.com/content/repositories/releases/'
 		}
 	}
 }

--- a/DemoNativeControls/app/build.gradle
+++ b/DemoNativeControls/app/build.gradle
@@ -10,7 +10,7 @@ if (isJenkinsBuild) {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
     defaultConfig {
         applicationId "com.jwplayer.demo.nativecontrols"
         minSdkVersion 24
@@ -50,7 +50,7 @@ android {
 }
 
 dependencies {
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
     implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
     implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 
@@ -70,7 +70,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
 
 ////    //  Only needed when building with AAR instead
-//    def media3version = '1.4.1'
+//    def media3version = '1.10.0'
 ////
 //    implementation 'androidx.appcompat:appcompat:1.4.1'
 ////

--- a/DemoNativeControls/build.gradle
+++ b/DemoNativeControls/build.gradle
@@ -19,7 +19,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/DrmDemo/app/build.gradle
+++ b/DrmDemo/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-	compileSdk 35
+	compileSdk 36
 
 	defaultConfig {
 		applicationId "com.jwplayer.drmdemo"
@@ -29,7 +29,7 @@ android {
 
 dependencies {
 
-	def jwPlayerVersion = '4.25.0'
+	def jwPlayerVersion = '4.26.0'
 	// JWPlayer SDK
 	implementation "com.jwplayer:jwplayer-core:$jwPlayerVersion"
 	implementation "com.jwplayer:jwplayer-common:$jwPlayerVersion"

--- a/DrmDemo/build.gradle
+++ b/DrmDemo/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 		mavenCentral()
 		gradlePluginPortal()
 		maven {
-			url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+			url 'https://mvn.jwplayer.com/content/repositories/releases/'
 		}
 	}
 }

--- a/FullBackgroundAudio/app/build.gradle
+++ b/FullBackgroundAudio/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-    compileSdk 35
+    compileSdk 36
     defaultConfig {
         applicationId "com.jwplayer.demo.fullbackgroundaudio"
         minSdkVersion 26
@@ -51,7 +51,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.media:media:1.6.0'
     
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
   	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
   	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 }

--- a/FullBackgroundAudio/build.gradle
+++ b/FullBackgroundAudio/build.gradle
@@ -16,7 +16,7 @@ allprojects {
         gradlePluginPortal()
         //JW Player maven repository
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/FullBackgroundAudio/gradle.properties
+++ b/FullBackgroundAudio/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/FullscreenWithoutRotationDemo/app/build.gradle
+++ b/FullscreenWithoutRotationDemo/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-	compileSdk 35
+	compileSdk 36
 	defaultConfig {
 		minSdkVersion 24
 		targetSdkVersion 35
@@ -53,7 +53,7 @@ dependencies {
 	implementation'com.google.android.material:material:1.9.0'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
   	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
   	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 

--- a/FullscreenWithoutRotationDemo/build.gradle
+++ b/FullscreenWithoutRotationDemo/build.gradle
@@ -19,7 +19,7 @@ allprojects {
 		mavenCentral()
 		gradlePluginPortal()
 		maven {
-			url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+			url 'https://mvn.jwplayer.com/content/repositories/releases/'
 		}
 	}
 }

--- a/GoogleDAIDemo/app/build.gradle
+++ b/GoogleDAIDemo/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.jwplayer.googledai"
@@ -55,7 +55,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
 	  implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
   	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
     implementation "com.jwplayer:jwplayer-ima:${sdkVersion}"

--- a/GoogleDAIDemo/build.gradle
+++ b/GoogleDAIDemo/build.gradle
@@ -22,7 +22,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
         
     }

--- a/ImaAdCompanions/app/build.gradle
+++ b/ImaAdCompanions/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.jwplayer.imaadcompanions"
@@ -38,7 +38,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
-    def jwPlayerVersion = '4.25.0'
+    def jwPlayerVersion = '4.26.0'
 
     implementation "com.jwplayer:jwplayer-core:$jwPlayerVersion"
     implementation "com.jwplayer:jwplayer-common:$jwPlayerVersion"

--- a/ImaAdCompanions/settings.gradle
+++ b/ImaAdCompanions/settings.gradle
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/JWCompose/app/build.gradle
+++ b/JWCompose/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
     namespace = "com.jwplayer.compose"
 
     defaultConfig {
@@ -27,18 +27,18 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     buildFeatures {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion kotlin_version
+        // Compose compiler 1.5.14 pairs with Kotlin 1.9.24 (set in the root build).
+        kotlinCompilerExtensionVersion '1.5.14'
     }
     packagingOptions {
         resources {
@@ -49,34 +49,31 @@ android {
 
 dependencies {
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.0")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0")
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.6'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6'
+    implementation 'androidx.activity:activity-compose:1.9.2'
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.material3:material3:1.1.2"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
+    // Jetpack Compose via the BOM so all Compose artifacts stay on one aligned version.
+    implementation platform('androidx.compose:compose-bom:2024.09.02')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.compose.ui:ui-viewbinding'
+    implementation 'androidx.compose.material:material'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.material:material-icons-extended'
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.13.0'
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.0"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
-    implementation "androidx.compose.ui:ui-viewbinding:$compose_version"
-
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.15.1'
-
-    def sdkVersion = '4.25.0'
+    // JW Player SDK — provides media3-based playback transitively (no direct ExoPlayer/media3 dep needed).
+    def sdkVersion = '4.26.0'
     implementation "com.jwplayer:jwplayer-core:$sdkVersion"
     implementation "com.jwplayer:jwplayer-common:$sdkVersion"
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.09.02')
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
 }

--- a/JWCompose/build.gradle
+++ b/JWCompose/build.gradle
@@ -1,17 +1,8 @@
-buildscript {
-    ext {
-        kotlin_version = '1.8.10'
-        compose_version = '1.4.3'
-    }
-    dependencies {
-        // classpath 'com.android.tools.build:gradle:7.1.3'
-        // classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
-    }
-}// Top-level build file where you can add configuration options common to all sub-projects/modules.
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '8.8.0' apply false
     id 'com.android.library' version '8.8.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
 }
 
 task clean(type: Delete) {

--- a/JWCompose/settings.gradle
+++ b/JWCompose/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
         google()
         mavenCentral()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }
@@ -14,7 +14,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/KotlinCustomUi/app/build.gradle.kts
+++ b/KotlinCustomUi/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
 	namespace = "com.jwplayer.customui"
-	compileSdk = 35
+	compileSdk = 36
 
 	defaultConfig {
 		minSdk = 24
@@ -36,8 +36,8 @@ android {
 }
 
 dependencies {
-	val JWPlayerVersion = "4.25.0"
-	val media3version = "1.4.1"
+	val JWPlayerVersion = "4.26.0"
+	val media3version = "1.10.0"
 
 	implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.0")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0")

--- a/KotlinCustomUi/settings.gradle.kts
+++ b/KotlinCustomUi/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
   repositories {
     google()
     mavenCentral()
-    maven { url = uri("https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/") }
+    maven { url = uri("https://mvn.jwplayer.com/content/repositories/releases/") }
   }
 }
 

--- a/LocalAssetPlayback/app/build.gradle
+++ b/LocalAssetPlayback/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-	compileSdk 35
+	compileSdk 36
 	
 	defaultConfig {
 		minSdkVersion 24
@@ -47,7 +47,7 @@ android {
 }
 
 dependencies {
-	def sdkVersion = '4.25.0'
+	def sdkVersion = '4.26.0'
 	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
 	implementation ("com.jwplayer:jwplayer-common:${sdkVersion}")
 

--- a/LocalAssetPlayback/build.gradle
+++ b/LocalAssetPlayback/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 		mavenCentral()
 		gradlePluginPortal()
 		maven {
-			url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+			url 'https://mvn.jwplayer.com/content/repositories/releases/'
 		}
 	}
 }

--- a/OfflineDelegate/app/build.gradle
+++ b/OfflineDelegate/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.jwplayer.offlinedelegate"
@@ -37,7 +37,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
-     def sdkVersion = '4.25.0'
+     def sdkVersion = '4.26.0'
     implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
     implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 

--- a/OfflineDelegate/settings.gradle
+++ b/OfflineDelegate/settings.gradle
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/OfflineDrmDemo/app/build.gradle
+++ b/OfflineDrmDemo/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.jwplayer.offlinedrmdemo"
@@ -34,7 +34,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
     implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
     implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 

--- a/OfflineDrmDemo/settings.gradle
+++ b/OfflineDrmDemo/settings.gradle
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/RecyclerViewDemo/app/build.gradle
+++ b/RecyclerViewDemo/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.jwplayer.demo.recyclerview"
@@ -59,7 +59,7 @@ dependencies {
 
     implementation group: 'com.google.android.gms', name: 'play-services-auth', version: '20.7.0'
 
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
   	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
   	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 

--- a/RecyclerViewDemo/build.gradle
+++ b/RecyclerViewDemo/build.gradle
@@ -19,7 +19,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/StylingDemo/app/build.gradle
+++ b/StylingDemo/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdk 35
+	compileSdk 36
 	defaultConfig {
 		minSdkVersion 24
 		targetSdkVersion 35
@@ -25,8 +25,8 @@ android {
     namespace 'com.jwplayer.stylingdemo'
 }
 
-ext.JWPlayerVersion = '4.25.0'
-ext.media3version = '1.4.1'
+ext.JWPlayerVersion = '4.26.0'
+ext.media3version = '1.10.0'
 
 dependencies {
 	implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/StylingDemo/build.gradle
+++ b/StylingDemo/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 		mavenCentral()
 		gradlePluginPortal()
 		maven {
-			url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+			url 'https://mvn.jwplayer.com/content/repositories/releases/'
 		}
 	}
 }

--- a/conviva-integration/app/build.gradle
+++ b/conviva-integration/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
 
@@ -56,7 +56,7 @@ dependencies {
     implementation('com.google.android.material:material:1.5.0')
 
 
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
   	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
   	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 

--- a/conviva-integration/build.gradle
+++ b/conviva-integration/build.gradle
@@ -19,7 +19,7 @@ allprojects {
 		mavenCentral()
 		gradlePluginPortal()
 		maven {
-			url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+			url 'https://mvn.jwplayer.com/content/repositories/releases/'
 		}
 	}
 }

--- a/listview-fullscreen/app/build.gradle
+++ b/listview-fullscreen/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.jwplayer.demo.listview"
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
 
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
   	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
   	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 

--- a/listview-fullscreen/build.gradle
+++ b/listview-fullscreen/build.gradle
@@ -19,7 +19,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/movable-player/app/build.gradle
+++ b/movable-player/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.jwplayer.demo.movableplayer"
@@ -57,7 +57,7 @@ dependencies {
 
 
     implementation 'androidx.dynamicanimation:dynamicanimation:1.0.0'
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
   	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
   	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 

--- a/movable-player/build.gradle
+++ b/movable-player/build.gradle
@@ -18,7 +18,7 @@ allprojects {
         google()
         mavenCentral()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }

--- a/notifications-demo/app/build.gradle
+++ b/notifications-demo/app/build.gradle
@@ -9,7 +9,7 @@ if (isJenkinsBuild) {
     props.load(new FileInputStream(propsFile))
 }
 android {
-    compileSdk 35
+    compileSdk 36
     
     defaultConfig {
         applicationId "com.jwplayer.demo.notificationsdemo"
@@ -55,7 +55,7 @@ dependencies {
     implementation'com.google.android.material:material:1.9.0'
     implementation 'androidx.media:media:1.6.0'
 
-    def sdkVersion = '4.25.0'
+    def sdkVersion = '4.26.0'
   	implementation "com.jwplayer:jwplayer-core:${sdkVersion}"
   	implementation "com.jwplayer:jwplayer-common:${sdkVersion}"
 

--- a/notifications-demo/build.gradle
+++ b/notifications-demo/build.gradle
@@ -19,7 +19,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven {
-            url 'https://nexus.longtailvideo.com/content/repositories/android-sdk-staging/'
+            url 'https://mvn.jwplayer.com/content/repositories/releases/'
         }
     }
 }


### PR DESCRIPTION
Updates all Best Practice Apps for the JW Player Android SDK **4.26.0** release.

## Changes
- JW Player SDK `4.24.x/4.25.0` → **4.26.0** across all demos
- media3 `1.4.1` → **1.10.0** where pinned directly; **compileSdk 35 → 36** across all demos (media3 1.10.0 requirement)
- Maven repo → **production** (`mvn.jwplayer.com/.../releases`); IMA `3.39.0` comes transitively
- **JWCompose modernized**: dropped dead ExoPlayer2 2.15.1 (playback via the SDK's media3 stack), Kotlin 1.8.10 → 1.9.24, Compose 1.4.3 → Compose BOM 2024.09.02 + compiler 1.5.14, Java 8 → 17
- FullBackgroundAudio: dropped a dead `-XX:MaxPermSize` jvmarg that crashed the build on Java 17

## Verified
On-device (physical, Android 15) against 4.26.0: CustomUi, ImaAdCompanions, GoogleDAIDemo, notifications-demo, and modernized JWCompose all build/install/run. `jwplayer-core:4.26.0` resolves from prod maven. License keys are placeholders; no staging pointers.

CnxAdServerDemo is intentionally excluded (cnx-ad-server-branch work).